### PR TITLE
add query param support to currencies method

### DIFF
--- a/Exchange.php
+++ b/Exchange.php
@@ -105,12 +105,12 @@ class Exchange
      * @return array
      * @throws GuzzleException
      */
-    public function currencies()
+    public function currencies(array $args = [])
     {
         return json_decode(
             $this
                 ->client
-                ->request('GET', '/currencies.json')
+                ->request('GET', '/currencies.json', ['query' => array_merge($args, $this->options)])
                 ->getBody()
                 ->getContents(),
             true


### PR DESCRIPTION
 Hello!
 
According to [oxr docs](https://oxr.readme.io/docs/currencies-json) `currency` endpoint supports query parameters, but the library doesn't support them.
 
 This PR adds query param support to `currencies` method.